### PR TITLE
Fixes: Fix Coverage Badge to Reflect the Actual value

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Xendit Coding Exercise
 
-[![Build Status](https://app.travis-ci.com/Anuoluwa/backend-coding-test.svg?branch=master)](https://app.travis-ci.com/Anuoluwa/backend-coding-test) [![Coverage Status](https://coveralls.io/repos/github/Anuoluwa/backend-coding-test/badge.svg?branch=master)](https://coveralls.io/github/Anuoluwa/backend-coding-test?branch=master)
+[![Build Status](https://app.travis-ci.com/Anuoluwa/backend-coding-test.svg?branch=master)](https://app.travis-ci.com/Anuoluwa/backend-coding-test)  [![Coverage Status](https://coveralls.io/repos/github/Anuoluwa/backend-coding-test/badge.svg?branch=master)](https://coveralls.io/github/Anuoluwa/backend-coding-test?branch=master)
  
 
 The goal of these exercises are to assess your proficiency in software engineering that is related to the daily work that we do at Xendit. Please follow the instructions below to complete the assessment.


### PR DESCRIPTION
What does this PR do?
Fixed the badge for coverage 

Description of Task to be completed?
Required tests threshold of 80%

How should this be manually tested?
- Clone the application and change the directory to the root folder
- Install the dependencies by running npm install
- Run `npm test` on the command.
- See the Readme on this repository

Any background context you want to provide?
Success Criteria
`nyc` should aim for test coverage of 80% across lines, statements, and branches

This criterion was met, but the badges did not reflect the threshold, this is fixed now